### PR TITLE
feature(port): Adds advertisement port option

### DIFF
--- a/lib/Monitor.js
+++ b/lib/Monitor.js
@@ -23,7 +23,7 @@ var Monitor = function(advertisement, discoveryOptions) {
         host = discoveryOptions && discoveryOptions.address || '0.0.0.0',
         interval = discoveryOptions.interval || 5000;
 
-    portfinder.getPort({host: host}, function(err, port) {
+    portfinder.getPort({host: host, port: advertisement.port}, function(err, port) {
         if (err) process.exit(err);
 
         advertisement.port = +port;

--- a/lib/Publisher.js
+++ b/lib/Publisher.js
@@ -18,7 +18,7 @@ var Publisher = function(advertisement, discoveryOptions) {
     this.advertisement = advertisement;
     var host = discoveryOptions && discoveryOptions.address || '0.0.0.0';
 
-    portfinder.getPort({ host: host }, function(err, port) {
+    portfinder.getPort({ host: host, port: advertisement.port }, function(err, port) {
         advertisement.axon_type = 'pub-emitter';
         advertisement.port = +port;
 

--- a/lib/Requester.js
+++ b/lib/Requester.js
@@ -17,7 +17,7 @@ var Requester = function(advertisement, discoveryOptions) {
     var that = this;
     var host = discoveryOptions && discoveryOptions.address || '0.0.0.0';
 
-    portfinder.getPort({ host: host }, function(err, port) {
+    portfinder.getPort({ host: host, port: advertisement.port }, function(err, port) {
         advertisement.axon_type = 'req';
         advertisement.port = +port;
         that.advertisement = advertisement;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "2.4.1",
     "node-discover": "0.4.0",
     "node-uuid": "1.4.1",
-    "portfinder": "0.4.0",
+    "portfinder": "1.0.x",
     "socket.io": "1.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds the ability to select what port to start checking for availability
and then bind to the first port starting with the provided port.
If not provided then the existing default behavior provided by
portfinder is used.

Also updates portfinder to '1.0.x'.