### PR TITLE
feature: Log message when no listener for event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,7 @@ Here's a list of environment variables cote supports:
 | `COTE_LOG`                  | Boolean. Whether to display hello and status logs for other discovered services. Has precedence over `COTE_STATUS_LOGS_ENABLED` and `COTE_HELLO_LOGS_ENABLED`.
 | `COTE_HELLO_LOGS_ENABLED`   | Boolean. Whether to display hello logs from other discovered services.
 | `COTE_STATUS_LOGS_ENABLED`  | Boolean. Whether to display status logs from other discovered services. Has precedence over `COTE_HELLO_LOGS_ENABLED`.
+| `COTE_LOG_UNKNOWN_EVENTS`   | Boolean. Whether to log a message when a responder or subscriber receives an event that it has no listeners for.
 | `COTE_CHECK_INTERVAL`       | Integer. The interval for checking if a discovered service has sent a heartbeat since the last check.
 | `COTE_HELLO_INTERVAL`       | Integer. The interval for sending a heartbeat hello signal. Should be less than `COTE_CHECK_INTERVAL`.
 | `COTE_NODE_TIMEOUT`         | Integer. The timeout duration that determines if a service is unreachable and thus removed. Should be greater than `COTE_CHECK_INTERVAL`.

--- a/src/components/responder.js
+++ b/src/components/responder.js
@@ -3,6 +3,9 @@ const portfinder = require('portfinder');
 const Configurable = require('./configurable');
 const Component = require('./component');
 
+// eslint-disable-next-line
+const colors = require('colors');
+
 module.exports = class Responder extends Configurable(Component) {
     constructor(advertisement, discoveryOptions) {
         super(advertisement, discoveryOptions);
@@ -12,6 +15,10 @@ module.exports = class Responder extends Configurable(Component) {
 
         this.sock.on('message', (req, cb) => {
             if (!req.type) return;
+
+            if (this.listeners(req.type).length === 0 && this.discoveryOptions.logUnknownEvents) {
+                this.discovery.log([this.advertisement.name, '>', `No listeners found for event: ${req.type}`.yellow]);
+            }
 
             this.emit(req.type, req, cb);
         });

--- a/src/components/subscriber.js
+++ b/src/components/subscriber.js
@@ -3,6 +3,9 @@ const Monitorable = require('./monitorable');
 const Component = require('./component');
 const axon = require('@dashersw/axon');
 
+// eslint-disable-next-line
+const colors = require('colors');
+
 module.exports = class Subscriber extends Monitorable(Configurable(Component)) {
     constructor(advertisement, discoveryOptions) {
         super(advertisement, discoveryOptions);
@@ -29,6 +32,11 @@ module.exports = class Subscriber extends Monitorable(Configurable(Component)) {
                     } else {
                         args[0] = namespace + args[0];
                     }
+
+                    if (this.listeners(args[0]).length === 0 && this.discoveryOptions.logUnknownEvents) {
+                        this.discovery.log([this.advertisement.name, '>', `No listeners found for event: ${args[0]}`.yellow]);
+                    }
+
                     this.emit(...args);
                 });
             })(topic);

--- a/src/options-builder.js
+++ b/src/options-builder.js
@@ -22,6 +22,7 @@ const envVarOptionsMap = {
     COTE_HELLO_LOGS_ENABLED: ['helloLogsEnabled', parser.bool],
     COTE_STATUS_LOGS_ENABLED: ['statusLogsEnabled', parser.bool],
     COTE_LOG: ['log', parser.bool],
+    COTE_LOG_UNKNOWN_EVENTS: ['logUnknownEvents', parser.bool],
     COTE_NODE_TIMEOUT: ['nodeTimeout', parser.int],
     COTE_IGNORE_PROCESS: ['ignoreProcess', parser.bool],
 };


### PR DESCRIPTION
Fixes #168 . This adds a log message when a responder or subscriber receives an event that it does not have a listener for. Logging is based on the cote `log` option and can be overridden at the Component level.