### PR TITLE
Bugfix responding to wildcard events with promises

### DIFF
--- a/src/components/responder.js
+++ b/src/components/responder.js
@@ -46,12 +46,11 @@ module.exports = class Responder extends Configurable(Component) {
     on(type, listener) {
         super.on(type, (...args) => {
             const rv = listener(...args);
+            
+            if (this.event.startsWith('cote:')) return;
 
             if (rv && typeof rv.then == 'function') {
-                let cb = args.pop();
-                if (typeof cb !== 'function') {
-                    cb = function() {};
-                }
+                const cb = args.pop();
                 rv.then((val) => cb(null, val)).catch(cb);
             }
         });

--- a/src/components/responder.js
+++ b/src/components/responder.js
@@ -48,7 +48,10 @@ module.exports = class Responder extends Configurable(Component) {
             const rv = listener(...args);
 
             if (rv && typeof rv.then == 'function') {
-                const cb = args.pop();
+                let cb = args.pop();
+                if (typeof cb !== 'function') {
+                    cb = function() {};
+                }
                 rv.then((val) => cb(null, val)).catch(cb);
             }
         });

--- a/test/request-response.js
+++ b/test/request-response.js
@@ -181,3 +181,36 @@ test.cb('Responder should log missing event listener', (t) => {
 
     requester.send({ type: 'missing', message: 'This should be ignored' });
 });
+
+
+test.cb('Responder supports listening for wildcard events', (t) => {
+    t.plan(3);
+
+    const key = r.generate();
+
+    const responder = new Responder({ name: `${t.title}: wildcard responder`, key });
+
+    responder.on('*', async (request) => {
+        // Ignore internal events
+        if (!request.type) {
+            return;
+        }
+        t.deepEqual(request.type, 'question');
+        t.deepEqual(request.value, [1, 2, 3]);
+        return [4, 5, 6];
+    });
+
+    // Wait a second, then create a requester and send a request
+
+    setTimeout(async function() {
+        const requester = new Requester({ name: `${t.title}: wildcard requester`, key });
+
+        try {
+            const response = await requester.send({ type: 'question', value: [1, 2, 3] });
+            t.deepEqual(response, [4, 5, 6]);
+            t.end();
+        } catch (error) {
+            console.error(`Caught error making request`, error);
+        }
+    }, 500);
+});

--- a/test/request-response.js
+++ b/test/request-response.js
@@ -205,12 +205,8 @@ test.cb('Responder supports listening for wildcard events', (t) => {
     setTimeout(async function() {
         const requester = new Requester({ name: `${t.title}: wildcard requester`, key });
 
-        try {
-            const response = await requester.send({ type: 'question', value: [1, 2, 3] });
-            t.deepEqual(response, [4, 5, 6]);
-            t.end();
-        } catch (error) {
-            console.error(`Caught error making request`, error);
-        }
+        const response = await requester.send({ type: 'question', value: [1, 2, 3] });
+        t.deepEqual(response, [4, 5, 6]);
+        t.end();
     }, 500);
 });

--- a/test/request-response.js
+++ b/test/request-response.js
@@ -200,7 +200,7 @@ test.cb('Responder supports listening for wildcard events', (t) => {
         return [4, 5, 6];
     });
 
-    // Wait a second, then create a requester and send a request
+    // Wait 500ms, then create a requester and send a request
 
     setTimeout(async function() {
         const requester = new Requester({ name: `${t.title}: wildcard requester`, key });


### PR DESCRIPTION
When responding to wildcard events with a promise, the `Responder` throws an unhandled promise rejection. This pull prevents that and adds an additional test to confirm it.

For example,

```javascript
const cote = require('cote');

const responder = new cote.Responder({ name: 'Example Responder' });

responder.on('*', async request => {

  if (!request.type) {
    return;
  }

  return 42;
});

setTimeout(async () => {

  const requester = new cote.Requester({ name: 'Example Requester' });

  await requester.send({ type: 'question' });

  process.exit();

}, 1000);
```

The above produces the the following warning:

```
(node:10352) UnhandledPromiseRejectionWarning: TypeError: cb is not a function
    at /Users/jesse/Development/Node/cote-test/node_modules/cote/src/components/responder.js:52:34
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

I'm not familiar enough with the codebase to tell if this is the best way to accomplish this, but all the tests pass. Hopefully this is helpful.

Thank you!

Fixes #91 