### PR TITLE
Add graceful shutdown for requesters and responders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+env:
+  - NODE_OPTIONS=–-max_old_space_size=4096
 matrix:
   include:
   - node_js: '10'

--- a/examples/requester.js
+++ b/examples/requester.js
@@ -32,3 +32,17 @@ function makeRequest() {
 makeRequest();
 
 setInterval(makeRequest, 5000);
+
+// Gracefully close responder after it completes any pending messages
+process.once('SIGINT', () => {
+    console.log('closing, press ctrl+c again to force exit');
+    randomRequest.close(() => {
+        console.log('exiting');
+        process.exit();
+    });
+
+    process.once('SIGINT', () => {
+        console.log('forced exit');
+        process.exit();
+    });
+});

--- a/examples/responder.js
+++ b/examples/responder.js
@@ -27,3 +27,17 @@ randomResponder.on('promised request', function(req) {
         // reject(answer);
     });
 });
+
+// Gracefully close responder after it completes any pending messages
+process.once('SIGINT', () => {
+    console.log('closing, press ctrl+c again to force exit');
+    randomResponder.close(() => {
+        console.log('exiting');
+        process.exit();
+    });
+
+    process.once('SIGINT', () => {
+        console.log('forced exit');
+        process.exit();
+    });
+});

--- a/src/components/component.js
+++ b/src/components/component.js
@@ -48,8 +48,28 @@ module.exports = class Component extends EventEmitter {
 
     onRemoved() { };
 
-    close() {
-        this.sock && this.sock.close();
+    close(cb) {
         this.discovery && this.discovery.stop();
+
+        if (typeof cb === 'function') {
+            const interval = setInterval(() => {
+                if (!this.messageIds || this.messageIds.length === 0) {
+                    if (this.sock) {
+                        if (this.sock.server) {
+                            this.sock.close(cb);
+                        } else {
+                            this.sock.close();
+                            cb();
+                        }
+                    } else {
+                        cb();
+                    }
+                    clearInterval(interval);
+                }
+            }, 100);
+            return;
+        } else {
+            this.sock && this.sock.close();
+        }
     }
 };

--- a/src/components/responder.js
+++ b/src/components/responder.js
@@ -2,6 +2,7 @@ const axon = require('@dashersw/axon');
 const portfinder = require('portfinder');
 const Configurable = require('./configurable');
 const Component = require('./component');
+const uuid = require('uuid');
 
 // eslint-disable-next-line
 const colors = require('colors');
@@ -9,6 +10,8 @@ const colors = require('colors');
 module.exports = class Responder extends Configurable(Component) {
     constructor(advertisement, discoveryOptions) {
         super(advertisement, discoveryOptions);
+
+        this.messageIds = [];
 
         this.sock = new axon.types[this.type]();
         this.sock.on('bind', () => this.startDiscovery());
@@ -20,7 +23,15 @@ module.exports = class Responder extends Configurable(Component) {
                 this.discovery.log([this.advertisement.name, '>', `No listeners found for event: ${req.type}`.yellow]);
             }
 
-            this.emit(req.type, req, cb);
+            const messageId = uuid.v4();
+            this.messageIds.push(messageId);
+            const cbWithCounter = (...cbArgs) => {
+                cb(...cbArgs);
+                const index = this.messageIds.indexOf(messageId);
+                index >= 0 && this.messageIds.splice(index, 1);
+            };
+
+            this.emit(req.type, req, cbWithCounter);
         });
 
         const onPort = (err, port) => {

--- a/test/component-lifecycle.js
+++ b/test/component-lifecycle.js
@@ -7,6 +7,27 @@ const { Requester, Responder } = require('../')({ environment });
 
 LogSuppress.init(console);
 
+const setup = (t) => {
+    const key = r.generate();
+
+    const requester = new Requester({ name: `${t.title}: ${key} requester`, key });
+    const responder = new Responder({ name: `${t.title}: ${key} responder`, key });
+
+    let i = 1;
+    responder.on('ping', (req, cb) => {
+        i++;
+        setTimeout(() => {
+            cb(null, 'pong');
+        }, 2000 * i);
+    });
+
+    for (let j = 0; j < 3; j++) {
+        requester.send({ type: 'ping' });
+    }
+
+    return { requester, responder };
+};
+
 test('Instantiate a requester', (t) => {
     const key = r.generate();
     const requester = new Requester({ name: `${t.title}: requester`, key });
@@ -28,4 +49,61 @@ test.cb('Discover and close a requester', (t) => {
         responder.close();
         t.end();
     });
+});
+
+test.cb(`Component should call close callback if no sock`, (t) => {
+    const key = r.generate();
+    const requester = new Requester({ name: `${t.title}: ${key} requester`, key });
+
+    setTimeout(() => {
+        requester.sock = null;
+        requester.close(() => {
+            t.is(requester.sock, null);
+            t.end();
+        });
+    }, 1000);
+});
+
+test.cb(`Requester should close socket immediately if no callback`, (t) => {
+    const { requester } = setup(t);
+
+    setTimeout(() => {
+        requester.close();
+        t.is(requester.messageIds.length, 3);
+        t.end();
+    }, 1000);
+});
+
+test.cb(`Requester should wait for all messages to complete before close callback`, (t) => {
+    const { requester } = setup(t);
+
+    setTimeout(() => {
+        requester.close(() => {
+            t.is(requester.messageIds.length, 0);
+            t.end();
+        });
+        t.is(requester.messageIds.length, 3);
+    }, 1000);
+});
+
+test.cb(`Responder should close socket immediately if no callback`, (t) => {
+    const { responder } = setup(t);
+
+    setTimeout(() => {
+        responder.close();
+        t.is(responder.messageIds.length, 3);
+        t.end();
+    }, 1000);
+});
+
+test.cb(`Responder should wait for all messages to complete before close callback`, (t) => {
+    const { responder } = setup(t);
+
+    setTimeout(() => {
+        responder.close(() => {
+            t.is(responder.messageIds.length, 0);
+            t.end();
+        });
+        t.is(responder.messageIds.length, 3);
+    }, 1000);
 });


### PR DESCRIPTION
Adds support for callback when calling `.close()` on a component to allow graceful shutdown.

If a callback is passed then the component will:

- immediately close discovery
- Wait for message queue to drain before calling callback

example use case:

```
const Responder = require('cote').Responder;

...

process.once('SIGINT', () => {
    randomResponder.close(() => {
        process.exit();
    });
});
```